### PR TITLE
Remove unused MaxRecvDataSegmentLength parameter

### DIFF
--- a/manifests/initiator.pp
+++ b/manifests/initiator.pp
@@ -72,7 +72,6 @@ class iscsi::initiator(
   $headerDigest = hiera('iscsi::headerDigest', $iscsi::params::headerDigest),
   $dataDigest = hiera('iscsi::dataDigest', $iscsi::params::dataDigest),
   $nr_sessions = hiera('iscsi::nr_sessions', $iscsi::params::nr_sessions),
-  $MaxRecvDataSegmentLength = hiera('iscsi::MaxRecvDataSegmentLength', $iscsi::params::MaxRecvDataSegmentLength),
   $fastAbort = hiera('iscsi::fastAbort', $iscsi::params::fastAbort),
   $iscsid_startup = hiera('iscsi::iscsid_startup', $iscsi::params::iscsid_startup),
   $iscsid_conf = hiera('iscsi::iscsid_conf', $iscsi::params::iscsid_conf)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,8 +53,6 @@ class iscsi::params {
   $dataDigest = None
   $nr_sessions = 1
 
-  $MaxRecvDataSegmentLength = 32768
-
   # Workarounds
   $fastAbort = true
 


### PR DESCRIPTION
This commit will remove unused and non-conform MaxRecvDataSegmentLength parameter.
It seems to be a duplicate of maxRecvDataSegmentLength, and causes issues with puppet 4.x+

Cheers !